### PR TITLE
Add generic Cradle interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ app.diContainer.resolve('userService')
 request.diScope.resolve('userService')
 request.diScope.resolve('user')
 ```
-Another usage [example from awlix docs](https://github.com/jeffijoe/awilix/blob/master/examples/typescript/src/index.ts)
+
+[Find more in tests](./index.test-d.ts) or in [example from awlix documentation](https://github.com/jeffijoe/awilix/blob/master/examples/typescript/src/index.ts)
 
 ## Advanced DI configuration
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ request.diScope.resolve('userService')
 request.diScope.resolve('user')
 ```
 
-[Find more in tests](./index.test-d.ts) or in [example from awlix documentation](https://github.com/jeffijoe/awilix/blob/master/examples/typescript/src/index.ts)
+[Find more in tests](./index.test-d.ts) or in [example from awilix documentation](https://github.com/jeffijoe/awilix/blob/master/examples/typescript/src/index.ts)
 
 ## Advanced DI configuration
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ diContainer.register({
 
 By default `fastify-awilix` is using generic empty `Cradle` and `RequestCradle` interfaces, it is possible extend it with your own types:
 
+`awlix` defines Cradle as a proxy, and all getters will trigger a container.resolve. [Read more](https://github.com/jeffijoe/awilix#containercradle)
+
 ```typescript
 declare module 'fastify-awilix' {
   interface Cradle {
@@ -137,6 +139,7 @@ app.diContainer.resolve('userService')
 request.diScope.resolve('userService')
 request.diScope.resolve('user')
 ```
+Another usage [example from awlix docs](https://github.com/jeffijoe/awilix/blob/master/examples/typescript/src/index.ts)
 
 ## Advanced DI configuration
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const fastify = require('fastify')
 
 app = fastify({ logger: true })
 app.register(fastifyAwilixPlugin, { disposeOnClose: true, disposeOnResponse: true })
-``` 
+```
 
 Then, register some modules for injection:
 
@@ -59,7 +59,7 @@ app.post('/', async (req, res) => {
   const userRepositoryForReq = req.diScope.resolve('userRepository')
   const userRepositoryForApp = app.diContainer.resolve('userRepository') // This returns exact same result as the previous line
   const userService = req.diScope.resolve('userService')
-  
+
   // Logic goes here
 
   res.send({
@@ -67,12 +67,12 @@ app.post('/', async (req, res) => {
   })
 })
 ```
-      
+
 
 ## Plugin options
 
-`disposeOnClose` - automatically invoke configured `dispose` for app-level `diContainer` hooks when the fastify instance is closed. 
-  Disposal is triggered within `onClose` fastify hook. 
+`disposeOnClose` - automatically invoke configured `dispose` for app-level `diContainer` hooks when the fastify instance is closed.
+  Disposal is triggered within `onClose` fastify hook.
   Default value is `true`
 
 `disposeOnResponse` - automatically invoke configured `dispose` for request-level `diScope` hooks after the reply is sent.
@@ -98,7 +98,7 @@ class UserRepository {
   constructor() {
     // Constructor logic goes here
   }
-  
+
   dispose() {
     // Disposal logic goes here
   }
@@ -113,7 +113,29 @@ diContainer.register({
     lifetime: Lifetime.SINGLETON,
     dispose: (module) => module.dispose(),
   }),
-})      
+})
+```
+
+## Typescript usage
+
+By default `fastify-awilix` is using generic empty `Cradle` and `RequestCradle` interfaces, it is possible extend it with your own types:
+
+```typescript
+declare module 'fastify-awilix' {
+  interface Cradle {
+    userService: UserService
+  }
+  interface RequestCradle {
+    user: User
+  }
+}
+//later, type is inferred correctly
+fastify.diContainer.cradle.userService
+// or
+app.diContainer.resolve('userService')
+// request scope
+request.diScope.resolve('userService')
+request.diScope.resolve('user')
 ```
 
 ## Advanced DI configuration

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ diContainer.register({
 
 ## Typescript usage
 
-By default `fastify-awilix` is using generic empty `Cradle` and `RequestCradle` interfaces, it is possible extend it with your own types:
+By default `fastify-awilix` is using generic empty `Cradle` and `RequestCradle` interfaces, it is possible extend them with your own types:
 
-`awlix` defines Cradle as a proxy, and all getters will trigger a container.resolve. [Read more](https://github.com/jeffijoe/awilix#containercradle)
+`awilix` defines Cradle as a proxy, and calling getters on it will trigger a container.resolve for an according module. [Read more](https://github.com/jeffijoe/awilix#containercradle)
 
 ```typescript
 declare module 'fastify-awilix' {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,15 @@
 import { AwilixContainer } from 'awilix'
 import { FastifyPluginCallback } from 'fastify'
 
+export interface Cradle {}
+
 declare module 'fastify' {
   interface FastifyRequest {
-    diScope: AwilixContainer
+    diScope: AwilixContainer<Cradle>
   }
 
   interface FastifyInstance {
-    diContainer: AwilixContainer
+    diContainer: AwilixContainer<Cradle>
   }
 }
 
@@ -18,4 +20,4 @@ export type FastifyAwilixOptions = {
 
 export const fastifyAwilixPlugin: FastifyPluginCallback<NonNullable<FastifyAwilixOptions>>
 
-export const diContainer: AwilixContainer
+export const diContainer: AwilixContainer<Cradle>

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,11 @@ import { FastifyPluginCallback } from 'fastify'
 
 export interface Cradle {}
 
+export interface RequestCradle {}
+
 declare module 'fastify' {
   interface FastifyRequest {
-    diScope: AwilixContainer<Cradle>
+    diScope: AwilixContainer<Cradle & RequestCradle>
   }
 
   interface FastifyInstance {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,53 @@
-import { AwilixContainer } from 'awilix'
-import fastify, { FastifyInstance } from "fastify";
-import { diContainer, FastifyAwilixOptions, fastifyAwilixPlugin, Cradle } from './'
+import { asValue, AwilixContainer } from 'awilix'
+import fastify, { FastifyInstance } from 'fastify'
+import { diContainer, FastifyAwilixOptions, fastifyAwilixPlugin, Cradle, RequestCradle } from './'
 import { expectAssignable, expectType } from 'tsd'
 
 expectAssignable<FastifyAwilixOptions>({})
-expectAssignable<FastifyAwilixOptions>({ disposeOnClose: false})
-expectAssignable<FastifyAwilixOptions>({ disposeOnResponse: false})
-expectType<AwilixContainer<Cradle>>(diContainer)
+expectAssignable<FastifyAwilixOptions>({ disposeOnClose: false })
+expectAssignable<FastifyAwilixOptions>({ disposeOnResponse: false })
 
-const app: FastifyInstance = fastify();
-app.register(fastifyAwilixPlugin, {});
+interface MailService {
+  greet(name: string): void
+}
+interface User {
+  name: string
+}
+
+declare module './' {
+  interface Cradle {
+    mailService: MailService
+  }
+  interface RequestCradle {
+    user: User
+  }
+}
+
+expectType<AwilixContainer<Cradle>>(diContainer)
+expectType<MailService>(diContainer.cradle.mailService)
+expectType<MailService>(diContainer.resolve('mailService'))
+
+const app: FastifyInstance = fastify()
+
+app.register(fastifyAwilixPlugin, {})
+
+app.addHook('onRequest', (request, reply, done) => {
+  request.diScope.register({
+    user: asValue({
+      name: 'John Doe',
+    }),
+  })
+  done()
+})
+
+app.get('/user', (request) => {
+  expectType<AwilixContainer<Cradle & RequestCradle>>(request.diScope)
+
+  const mailService = request.diScope.cradle.mailService
+  const user = request.diScope.cradle.user
+
+  expectType<MailService>(mailService)
+  expectType<User>(user)
+
+  mailService.greet(user.name)
+})

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,12 @@
 import { AwilixContainer } from 'awilix'
 import fastify, { FastifyInstance } from "fastify";
-import { diContainer, FastifyAwilixOptions, fastifyAwilixPlugin } from './'
+import { diContainer, FastifyAwilixOptions, fastifyAwilixPlugin, Cradle } from './'
 import { expectAssignable, expectType } from 'tsd'
 
 expectAssignable<FastifyAwilixOptions>({})
 expectAssignable<FastifyAwilixOptions>({ disposeOnClose: false})
 expectAssignable<FastifyAwilixOptions>({ disposeOnResponse: false})
-expectType<AwilixContainer>(diContainer)
+expectType<AwilixContainer<Cradle>>(diContainer)
 
 const app: FastifyInstance = fastify();
 app.register(fastifyAwilixPlugin, {});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import { asValue, AwilixContainer } from 'awilix'
 import fastify, { FastifyInstance } from 'fastify'
 import { diContainer, FastifyAwilixOptions, fastifyAwilixPlugin, Cradle, RequestCradle } from './'
-import { expectAssignable, expectType } from 'tsd'
+import { expectAssignable, expectNotType, expectType } from 'tsd'
 
 expectAssignable<FastifyAwilixOptions>({})
 expectAssignable<FastifyAwilixOptions>({ disposeOnClose: false })
@@ -24,6 +24,10 @@ declare module './' {
 }
 
 expectType<AwilixContainer<Cradle>>(diContainer)
+
+expectNotType<AwilixContainer<Cradle & RequestCradle>>(diContainer)
+expectNotType<AwilixContainer<RequestCradle>>(diContainer)
+
 expectType<MailService>(diContainer.cradle.mailService)
 expectType<MailService>(diContainer.resolve('mailService'))
 


### PR DESCRIPTION
It allows to refine Cradle interface when used:

```typescript
declare module 'fastify-awilix' {
  interface Cradle {
    authService: AuthService;
  }
}
//later, type is inferred correctly
fastify.diContainer.cradle.authService
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
