### PR TITLE
Prevented duplicate "request completed" logs

### DIFF
--- a/lib/classic/index.js
+++ b/lib/classic/index.js
@@ -21,13 +21,13 @@ function plugin(fastify, opts, next) {
 
   if (disposeOnClose) {
     fastify.addHook('onClose', (instance, done) => {
-      return diContainer.dispose().then(done, done)
+      diContainer.dispose().then(done, done)
     })
   }
 
   if (disposeOnResponse) {
     fastify.addHook('onResponse', (request, reply, done) => {
-      return request.diScope.dispose().then(done, done)
+      request.diScope.dispose().then(done, done)
     })
   }
 

--- a/lib/fastifyAwilixPlugin.js
+++ b/lib/fastifyAwilixPlugin.js
@@ -25,7 +25,7 @@ function plugin(fastify, opts, next) {
 
   if (disposeOnResponse) {
     fastify.addHook('onResponse', (request, reply, done) => {
-      request.diScope.dispose().then(done)
+      request.diScope.dispose().then(done, done)
     })
   }
 

--- a/lib/fastifyAwilixPlugin.js
+++ b/lib/fastifyAwilixPlugin.js
@@ -19,13 +19,13 @@ function plugin(fastify, opts, next) {
 
   if (disposeOnClose) {
     fastify.addHook('onClose', (instance, done) => {
-      return diContainer.dispose().then(done)
+      diContainer.dispose().then(done)
     })
   }
 
   if (disposeOnResponse) {
     fastify.addHook('onResponse', (request, reply, done) => {
-      return request.diScope.dispose().then(done)
+      request.diScope.dispose().then(done)
     })
   }
 

--- a/lib/fastifyAwilixPlugin.js
+++ b/lib/fastifyAwilixPlugin.js
@@ -19,7 +19,7 @@ function plugin(fastify, opts, next) {
 
   if (disposeOnClose) {
     fastify.addHook('onClose', (instance, done) => {
-      diContainer.dispose().then(done)
+      diContainer.dispose().then(done, done)
     })
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

I noticed that two "request completed" logs were being printed by my Fastify instance following the "incoming request" log.  After setting some breakpoints, I narrowed down the cause of this behavior to this plugin, specifically the `onResponse` hook controlled by the `disposeOnResponse` option.  Removing the `return` from the hook callback stopped the extra log from being printed.  Alternatively, using async/await will also fix this problem.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
