### PR TITLE
test: tidy syntax

### DIFF
--- a/test/fastifyAwilixPlugin.dispose.spec.js
+++ b/test/fastifyAwilixPlugin.dispose.spec.js
@@ -43,7 +43,7 @@ describe('fastifyAwilixPlugin', () => {
       const endpoint = async (req, res) => {
         const userRepository = app.diContainer.resolve('userRepository')
         storedUserRepository = userRepository
-        expect(userRepository.disposeCounter).toEqual(0)
+        expect(userRepository.disposeCounter).toBe(0)
 
         res.send({
           status: 'OK',
@@ -56,8 +56,8 @@ describe('fastifyAwilixPlugin', () => {
           const userRepositoryScoped = req.diScope.resolve('userRepositoryScoped')
           storedUserRepository = userRepository
           storedUserRepositoryScoped = userRepositoryScoped
-          expect(userRepository.disposeCounter).toEqual(0)
-          expect(userRepositoryScoped.disposeCounter).toEqual(0)
+          expect(userRepository.disposeCounter).toBe(0)
+          expect(userRepositoryScoped.disposeCounter).toBe(0)
 
           res.send({
             status: 'OK',
@@ -78,11 +78,11 @@ describe('fastifyAwilixPlugin', () => {
           await app.ready()
 
           const response = await app.inject().post('/').end()
-          expect(response.statusCode).toEqual(200)
-          expect(storedUserRepository.disposeCounter).toEqual(0)
+          expect(response.statusCode).toBe(200)
+          expect(storedUserRepository.disposeCounter).toBe(0)
 
           await app.close()
-          expect(storedUserRepository.disposeCounter).toEqual(1)
+          expect(storedUserRepository.disposeCounter).toBe(1)
         })
 
         it('do not dispose app-scoped singletons on sending response', async () => {
@@ -99,11 +99,11 @@ describe('fastifyAwilixPlugin', () => {
           await app.ready()
 
           const response = await app.inject().post('/').end()
-          expect(response.statusCode).toEqual(200)
-          expect(storedUserRepository.disposeCounter).toEqual(0)
+          expect(response.statusCode).toBe(200)
+          expect(storedUserRepository.disposeCounter).toBe(0)
 
           await app.close()
-          expect(storedUserRepository.disposeCounter).toEqual(0)
+          expect(storedUserRepository.disposeCounter).toBe(0)
         })
 
         it('dispose request-scoped singletons on sending response', async () => {
@@ -130,13 +130,13 @@ describe('fastifyAwilixPlugin', () => {
           await app.ready()
 
           const response = await app.inject().post('/').end()
-          expect(response.statusCode).toEqual(200)
-          expect(storedUserRepositoryScoped.disposeCounter).toEqual(1)
-          expect(storedUserRepository.disposeCounter).toEqual(0)
+          expect(response.statusCode).toBe(200)
+          expect(storedUserRepositoryScoped.disposeCounter).toBe(1)
+          expect(storedUserRepository.disposeCounter).toBe(0)
 
           await app.close()
-          expect(storedUserRepositoryScoped.disposeCounter).toEqual(1)
-          expect(storedUserRepository.disposeCounter).toEqual(0)
+          expect(storedUserRepositoryScoped.disposeCounter).toBe(1)
+          expect(storedUserRepository.disposeCounter).toBe(0)
         })
 
         it('do not dispose request-scoped singletons twice on closing app', async () => {
@@ -163,13 +163,13 @@ describe('fastifyAwilixPlugin', () => {
           await app.ready()
 
           const response = await app.inject().post('/').end()
-          expect(response.statusCode).toEqual(200)
-          expect(storedUserRepositoryScoped.disposeCounter).toEqual(1)
-          expect(storedUserRepository.disposeCounter).toEqual(0)
+          expect(response.statusCode).toBe(200)
+          expect(storedUserRepositoryScoped.disposeCounter).toBe(1)
+          expect(storedUserRepository.disposeCounter).toBe(0)
 
           await app.close()
-          expect(storedUserRepositoryScoped.disposeCounter).toEqual(1)
-          expect(storedUserRepository.disposeCounter).toEqual(1)
+          expect(storedUserRepositoryScoped.disposeCounter).toBe(1)
+          expect(storedUserRepository.disposeCounter).toBe(1)
         })
       })
 
@@ -197,7 +197,7 @@ describe('fastifyAwilixPlugin', () => {
           await app.inject().post('/').end()
 
           await app.close()
-          expect(requestCompletedLogCount).toEqual(1)
+          expect(requestCompletedLogCount).toBe(1)
         })
 
         it('should only produce one "request completed" log with dispose settings disabled', async () => {
@@ -223,7 +223,7 @@ describe('fastifyAwilixPlugin', () => {
           await app.inject().post('/').end()
 
           await app.close()
-          expect(requestCompletedLogCount).toEqual(1)
+          expect(requestCompletedLogCount).toBe(1)
         })
       })
     })

--- a/test/fastifyAwilixPlugin.spec.js
+++ b/test/fastifyAwilixPlugin.spec.js
@@ -60,12 +60,12 @@ describe('fastifyAwilixPlugin', () => {
           app = fastify({ logger: true })
           const endpoint = async (req, res) => {
             const userService = app.diContainer.resolve('userService')
-            expect(userService.userRepository.id).toEqual('userRepository')
-            expect(userService.maxUserName).toEqual(10)
-            expect(userService.maxEmail).toEqual(40)
+            expect(userService.userRepository.id).toBe('userRepository')
+            expect(userService.maxUserName).toBe(10)
+            expect(userService.maxEmail).toBe(40)
 
             const maxUserPassword = await req.diScope.resolve('maxUserPassword')
-            expect(maxUserPassword).toEqual(20)
+            expect(maxUserPassword).toBe(20)
             res.send({
               status: 'OK',
             })
@@ -86,7 +86,7 @@ describe('fastifyAwilixPlugin', () => {
           await app.ready()
 
           const response = await app.inject().post('/').end()
-          expect(response.statusCode).toEqual(200)
+          expect(response.statusCode).toBe(200)
         })
       })
     })


### PR DESCRIPTION
This PR:

- replaces use of `toEqual()` with `toBe()` when expecting primitive literals, as [recommended in Jest documentation](https://jestjs.io/docs/expect#tobevalue)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
