### PR TITLE
Handle early reply correctly

### DIFF
--- a/lib/fastifyAwilixPlugin.js
+++ b/lib/fastifyAwilixPlugin.js
@@ -25,7 +25,9 @@ function plugin(fastify, opts, next) {
 
   if (disposeOnResponse) {
     fastify.addHook('onResponse', (request, reply, done) => {
-      request.diScope.dispose().then(done, done)
+      if (request.diScope) {
+        request.diScope.dispose().then(done, done)
+      }
     })
   }
 


### PR DESCRIPTION
Sometimes we reply before we had a chance to instantiate request scope. In that case we shouldn't dispose it (or we'll get an undefined error)

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
