### PR TITLE
Bump version of awilix-manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier": "prettier --write \"{lib,test}/**/*.js\" lib/index.js lib/index.d.ts"
   },
   "dependencies": {
-    "awilix-manager": "^2.0.0",
+    "awilix-manager": "^3.0.0",
     "fastify-plugin": "^4.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier": "prettier --write \"{lib,test}/**/*.js\" lib/index.js lib/index.d.ts"
   },
   "dependencies": {
-    "awilix-manager": "^1.0.1",
+    "awilix-manager": "^2.0.0",
     "fastify-plugin": "^4.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Export configuration change is the only difference between versions, and this should be a drop-in replacement for fastify.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
