### PR TITLE
test(fastifyAwilixPlugin.dispose): remove unused catch binding

### DIFF
--- a/test/fastifyAwilixPlugin.dispose.test.js
+++ b/test/fastifyAwilixPlugin.dispose.test.js
@@ -35,7 +35,7 @@ function getCompletedRequests (output) {
   return output.filter((line) => {
     try {
       return JSON.parse(line).msg === 'request completed'
-    } catch (e) {
+    } catch {
       return false
     }
   })


### PR DESCRIPTION
No point binding this