### PR TITLE
feat: Adjust configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ Disposal is triggered within `onResponse` fastify hook.
 Default value is `true`
 
 `asyncInit` - whether to process `asyncInit` fields in DI resolver configuration. Note that all dependencies with asyncInit enabled are instantiated eagerly. Disabling this will make app startup slightly faster.
-Default value is `false`
+Default value is `true`
 
 `asyncDispose` - whether to process `asyncDispose` fields in DI resolver configuration when closing the fastify app. Disabling this will make app closing slightly faster.
-Default value is `false`
+Default value is `true`
 
 `eagerInject` - whether to process `eagerInject` fields in DI resolver configuration, which instantiates and caches module immediately. Disabling this will make app startup slightly faster.
-Default value is `false`
+Default value is `true`
 
-`strictBooleanEnforced` - whether to throw an error if `enabled` field in a resolver configuration is set with an unsupported value (anything different from `true` and `false`). It is recommended to set this to `true`, which will be a default value in the next semver major release.
-Default value is `false`
+`strictBooleanEnforced` - whether to throw an error if `enabled` field in a resolver configuration is set with an unsupported value (anything different from `true` and `false`).
+Default value is `true`
 
 ## Defining classes
 

--- a/lib/fastifyAwilixPlugin.js
+++ b/lib/fastifyAwilixPlugin.js
@@ -13,6 +13,11 @@ const diContainerClassic = awilix.createContainer({
 })
 
 function plugin (fastify, opts, next) {
+  const asyncInitEnabled = opts.asyncInit ?? true
+  const eagerInjectEnabled = opts.eagerInject ?? true
+  const asyncDisposeEnabled = opts.asyncDispose ?? true
+  const strictBooleanEnforced = opts.strictBooleanEnforced ?? true
+
   if (opts.container && opts.injectionMode) {
     return next(
       new Error(
@@ -29,10 +34,10 @@ function plugin (fastify, opts, next) {
 
   const awilixManager = new AwilixManager({
     diContainer: resolvedContainer,
-    asyncDispose: opts.asyncDispose,
-    asyncInit: opts.asyncInit,
-    eagerInject: opts.eagerInject,
-    strictBooleanEnforced: opts.strictBooleanEnforced
+    asyncInit: asyncInitEnabled,
+    eagerInject: eagerInjectEnabled,
+    asyncDispose: asyncDisposeEnabled,
+    strictBooleanEnforced,
   })
   const disposeOnResponse = opts.disposeOnResponse === true || opts.disposeOnResponse === undefined
   const disposeOnClose = opts.disposeOnClose === true || opts.disposeOnClose === undefined
@@ -46,7 +51,7 @@ function plugin (fastify, opts, next) {
     done()
   })
 
-  if (opts.asyncInit || opts.eagerInject) {
+  if (asyncInitEnabled || eagerInjectEnabled) {
     fastify.addHook('onReady', function awilixOnReady (done) {
       const startTime = Date.now()
       fastify.log.debug('Start async awilix init')
@@ -67,7 +72,7 @@ function plugin (fastify, opts, next) {
   }
 
   if (disposeOnClose) {
-    fastify.addHook('onClose', (instance, done) => {
+    fastify.addHook('onClose', function awilixOnClose (instance, done) {
       if (instance.awilixManager.config.asyncDispose) {
         instance.awilixManager
           .executeDispose()
@@ -80,7 +85,7 @@ function plugin (fastify, opts, next) {
   }
 
   if (disposeOnResponse) {
-    fastify.addHook('onResponse', (request, _reply, done) => {
+    fastify.addHook('onResponse', function awilixOnResponse (request, _reply, done) {
       if (request.diScope) {
         request.diScope.dispose().then(done, done)
       }

--- a/test/fastifyAwilixPlugin.dispose.test.js
+++ b/test/fastifyAwilixPlugin.dispose.test.js
@@ -89,6 +89,7 @@ describe('fastifyAwilixPlugin', () => {
           app.register(fastifyAwilixPlugin, {
             disposeOnClose: true,
             disposeOnResponse: false,
+            asyncDispose: false,
             injectionMode: variation.injectionMode
           })
           variation.container.register({
@@ -116,6 +117,7 @@ describe('fastifyAwilixPlugin', () => {
           app.register(fastifyAwilixPlugin, {
             disposeOnClose: false,
             disposeOnResponse: true,
+            asyncDispose: false,
             injectionMode: variation.injectionMode
           })
           variation.container.register({
@@ -147,6 +149,7 @@ describe('fastifyAwilixPlugin', () => {
           await app.register(fastifyAwilixPlugin, {
             disposeOnClose: false,
             disposeOnResponse: true,
+            asyncDispose: false,
             injectionMode: variation.injectionMode
           })
           variation.container.register({
@@ -181,6 +184,7 @@ describe('fastifyAwilixPlugin', () => {
           app.register(fastifyAwilixPlugin, {
             disposeOnClose: false,
             disposeOnResponse: true,
+            asyncDispose: false,
             injectionMode: variation.injectionMode
           })
 
@@ -220,6 +224,7 @@ describe('fastifyAwilixPlugin', () => {
           app.register(fastifyAwilixPlugin, {
             disposeOnClose: true,
             disposeOnResponse: true,
+            asyncDispose: false,
             injectionMode: variation.injectionMode
           })
 
@@ -261,6 +266,7 @@ describe('fastifyAwilixPlugin', () => {
           app.register(fastifyAwilixPlugin, {
             disposeOnClose: true,
             disposeOnResponse: true,
+            asyncDispose: false,
             injectionMode: variation.injectionMode
           })
           variation.container.register({
@@ -287,6 +293,7 @@ describe('fastifyAwilixPlugin', () => {
           app.register(fastifyAwilixPlugin, {
             disposeOnClose: false,
             disposeOnResponse: false,
+            asyncDispose: false,
             injectionMode: variation.injectionMode
           })
           variation.container.register({

--- a/test/fastifyAwilixPlugin.test.js
+++ b/test/fastifyAwilixPlugin.test.js
@@ -106,6 +106,8 @@ describe('fastifyAwilixPlugin', () => {
             }
 
             app.register(fastifyAwilixPlugin, {
+              asyncInit: false,
+              eagerInject: false,
               injectionMode: variation.optsInjectionMode,
               container: variation.optsContainer
             })
@@ -137,6 +139,8 @@ describe('fastifyAwilixPlugin', () => {
 
       await assert.rejects(async () => {
         await app.register(fastifyAwilixPlugin, {
+          asyncInit: false,
+          eagerInject: false,
           injectionMode: 'PROXY',
           container: diContainer
         })
@@ -148,6 +152,7 @@ describe('fastifyAwilixPlugin', () => {
     it('handles DI timeout', async () => {
       app = fastify({ logger: { level: 'debug' } })
       app.register(fastifyAwilixPlugin, {
+        eagerInject: false,
         container: diContainer,
         asyncInit: true
       })


### PR DESCRIPTION
This provides a more sensible default that is going to be more helpful in most cases. Disabling any of the operations is a microoptimization that only should be done when absolutely necessary, but in typical usage scenarios this can just cause confusing bugs.


#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
