### PR TITLE
Use HTTPS for package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "neostandard": "^0.13.0",
     "tstyche": "^7.0.0"
   },
-  "homepage": "http://github.com/fastify/fastify-awilix",
+  "homepage": "https://github.com/fastify/fastify-awilix",
   "funding": [
     {
       "type": "github",
@@ -69,7 +69,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/fastify/fastify-awilix.git"
+    "url": "https://github.com/fastify/fastify-awilix.git"
   },
   "bugs": {
     "url": "https://github.com/fastify/fastify-awilix/issues"


### PR DESCRIPTION
## Summary\n- update the package homepage URL to HTTPS\n- update the package repository URL to HTTPS instead of the legacy git protocol\n\n## Validation\n- git diff --check\n- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'